### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,12 +7,12 @@
 #######################################
 
 Fri3dMatrix	KEYWORD1
-Fri3dServo KEYWORD1
-Fri3dLegs KEYWORD1
-Fri3dServoJewel KEYWORD1
-Fri3dBuzzer KEYWORD1
-Fri3dButtons KEYWORD1
-Fri3dAccelerometer KEYWORD1
+Fri3dServo	KEYWORD1
+Fri3dLegs	KEYWORD1
+Fri3dServoJewel	KEYWORD1
+Fri3dBuzzer	KEYWORD1
+Fri3dButtons	KEYWORD1
+Fri3dAccelerometer	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords